### PR TITLE
-fix error message accessing object

### DIFF
--- a/Resources/views/Emails/ticket.update.html.twig
+++ b/Resources/views/Emails/ticket.update.html.twig
@@ -2,8 +2,8 @@
 <body>
 <p>{{ 'emails.ticket.update.content'|trans({
         '%number%': ticket.id,
-        '%sender%': ticket.messages|last.message.userObject.username,
-        '%date%': ticket.messages|last.createdAt|date('LABEL_DATE_TIME_FORMAT'|trans)
+        '%sender%': ticket.lastUserObject.username,
+        '%date%': ticket.lastMessage|date('LABEL_DATE_TIME_FORMAT'|trans)
     }) }}</p>
 <div style="width:100%;background-color:#f0f0f0;border:1px solid #000;">
     <p style="margin:0;padding:20px 20px 0;"><b>{{ ticket.subject }}</b></p>

--- a/Resources/views/Emails/ticket.update.txt.twig
+++ b/Resources/views/Emails/ticket.update.txt.twig
@@ -1,7 +1,7 @@
 {{ 'emails.ticket.update.content'|trans({
         '%number%': ticket.id,
-        '%sender%': ticket.messages|last.message.userObject.username,
-        '%date%': ticket.messages|last.createdAt|date('LABEL_DATE_TIME_FORMAT'|trans)
+        '%sender%': ticket.lastUserObject.username,
+        '%date%': ticket.lastMessage|date('LABEL_DATE_TIME_FORMAT'|trans)
     }) }}
 
 {{ ticket.subject }}


### PR DESCRIPTION
I use the last values of the ticket object instead of search for the last of the messages persistent collection

```
#lastUser: 1
  #lastUserObject: BaseUser {#121}
  #lastMessage: DateTime {#1315
    +"date": "2017-05-12 11:40:00.000000"
    +"timezone_type": 3
    +"timezone": "Europe/Berlin"
  }
```

Can you review if it's ok for you, and if this code do the same as you have done ?

