### PR TITLE
Added support for Swift Mailer 6

### DIFF
--- a/Mailer/Mailer.php
+++ b/Mailer/Mailer.php
@@ -126,8 +126,7 @@ class Mailer
     private function prepareEmailMessage($subject, $to)
     {
         // Prepare a confirmation e-mail
-        return \Swift_Message::newInstance()
-            ->setSubject($subject)
+        return (new \Swift_Message($subject))
             ->setFrom(array(
                 $this->container->getParameter('flodaq_ticket_notification.emails')['sender_email']
                     => $this->container->getParameter('flodaq_ticket_notification.emails')['sender_name']


### PR DESCRIPTION
\Swift_Message::newInstance() was deprecated and was removed in  Swift Mailer 6